### PR TITLE
Updating Ruter plugin to using Entur API

### DIFF
--- a/plugins/ruter/test_ruter.py
+++ b/plugins/ruter/test_ruter.py
@@ -4,4 +4,4 @@ def test_get_station():
     name = 'Forskningsparken'
     stations = ruter.get_stations(name)
 
-    assert name in stations[0]['Name']
+    assert name in stations[0]['properties']['name']


### PR DESCRIPTION
# Use of Entur API
This PR updates the Ruter-plugin so that it uses the [Entur APIs](https://developer.entur.org/) rather than the deprecated [Ruter API](https://reisapi.ruter.no/help).

It uses the [Geocoder API](https://developer.entur.org/pages-geocoder-intro) to fetch the IDs and names for the stops. The plugin sends a GET-request which returns a list of viable stops in the Entur network in Oslo.
```
https://api.entur.io/geocoder/v1/autocomplete?text={name of stop}&lang=no
```

The [Journey Planner API](https://developer.entur.org/pages-journeyplanner-journeyplanner) is used to get the departures from each viable stop. The depature information is retrieved from a POST-request to a GraphQL endpoint.
```
https://api.entur.io/journey-planner/v2/graphql
```

For both APIs, the header field `ET-Client-Name` is required. This header is used by Entur to make sure that each consumer of the API identifies themselves. If this header was not supplied, the requests would be blocked. The header must have the form `<company_name> - <application_name>`. I have set this header to be `cybernetisk_selskab - internsystem`.